### PR TITLE
Fix deprecation warnings from puppet and some tidy up suggested by lint.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,30 +1,37 @@
 class google_chrome::config() inherits google_chrome::params {
   case $::osfamily {
     'RedHat': {
-      yumrepo { $google_chrome::params::repo_name: 
+      yumrepo { $google_chrome::params::repo_name:
         enabled  => 1,
         gpgcheck => 1,
         baseurl  => $google_chrome::params::repo_base_url,
         gpgkey   => $google_chrome::params::repo_gpg_key,
       }
-    } 
+    }
     'Debian': {
       apt::source { $google_chrome::params::repo_name:
-        location          => $google_chrome::params::repo_base_url,
-        release           => 'stable',
-        key_source        => $google_chrome::params::repo_gpg_key,
-        key               => '7FAC5991',
-        repos             => 'main',
-        include_src       => false,
-      }    
+        location => $google_chrome::params::repo_base_url,
+        release  => 'stable',
+        key      => {
+          id     => '4CCA1EAF950CEE4AB83976DCA040830F7FAC5991',
+          source => 'http://dl-ssl.google.com/linux/linux_signing_key.pub'
+        },
+        repos    => 'main',
+        include  => {
+          'src' => false
+        },
+      }
     }
     'Suse': {
       zypprepo { $google_chrome::params::repo_name:
         baseurl  => $google_chrome::params::repo_base_url,
         enabled  => 1,
         gpgcheck => 0,
-        type     => "rpm-md",
-      }    
+        type     => 'rpm-md',
+      }
     }
-  }  
+    default: {
+      fail("Unsupported operating system family ${::osfamily}")
+    }
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class google_chrome::params() {
     'RedHat', 'Suse': {
       case $::operatingsystem {
         'Fedora', 'OpenSuSE': {
-          $repo_base_url = 'http://dl.google.com/linux/chrome/rpm/stable/$basearch'      
+          $repo_base_url = 'http://dl.google.com/linux/chrome/rpm/stable/$basearch'
         }
         default: {
           fail("Unsupported operating system ${::operatingsystem}")


### PR DESCRIPTION
Fixes for the following warnings ,which I get running with Puppet 3.4.3 on Mint 17.2:

```
Warning: Scope(Apt::Source[google-chrome]): $include_src is deprecated and will be removed in the next major release, please use $include => { 'src' => false } instead
Warning: Scope(Apt::Source[google-chrome]): $key_source is deprecated and will be removed in the next major release, please use $key => { 'source' => http://dl-ssl.google.com/linux/linux_signing_key.pub } instead.
Warning: Scope(Apt::Key[Add key: 7FAC5991 from Apt::Source google-chrome]): $key_source is deprecated and will be removed in the next major release. Please use $source instead.
Warning: /Apt_key[Add key: 7FAC5991 from Apt::Source google-chrome]: The id should be a full fingerprint (40 characters), see README.
```