### PR TITLE
Support CentOS/RHEL

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,14 +7,7 @@ class google_chrome::params() {
 
   case $::osfamily {
     'RedHat', 'Suse': {
-      case $::operatingsystem {
-        'Fedora', 'OpenSuSE': {
-          $repo_base_url = 'http://dl.google.com/linux/chrome/rpm/stable/$basearch'
-        }
-        default: {
-          fail("Unsupported operating system ${::operatingsystem}")
-        }
-      }
+      $repo_base_url = 'http://dl.google.com/linux/chrome/rpm/stable/$basearch'
     }
     'Debian': {
       $repo_base_url = 'http://dl.google.com/linux/chrome/deb/'


### PR DESCRIPTION
As per issues #5, this is one approach to support CentOS RHEL. Google does not officially support RHEL, but Chrome currently works on EL7.
This PR does not attempt to enforce any OS versions, but just uses the osfamily to decide if to install a deb or rpm.