### PR TITLE
Fix apt-get update errors on Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class google_chrome::params() {
       $repo_base_url = 'http://dl.google.com/linux/chrome/rpm/stable/$basearch'
     }
     'Debian': {
-      $repo_base_url = 'http://dl.google.com/linux/chrome/deb/'
+      $repo_base_url = '[arch=amd64] http://dl.google.com/linux/chrome/deb/'
     }
     default: {
       fail("Unsupported operating system family ${::osfamily}")


### PR DESCRIPTION
Google has pulled the 32 bit version from there repos and we need to tell apt to only look for the 64 bit version