### PR TITLE
Add failure mode for Enterprise Linux 6. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ spec/fixtures
 pkg
 Dockerfile
 Vagrantfile
+vendor
+.bundle

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,13 @@ class google_chrome::params() {
   $repo_name     = 'google-chrome'
 
   case $::osfamily {
-    'RedHat', 'Suse': {
+    'RedHat' : {
+      if $::os[release][major] == '6' {
+	fail("Operating system not supported by Google Chrome")
+      }
+      $repo_base_url = 'http://dl.google.com/linux/chrome/rpm/stable/$basearch'
+    }
+    'Suse' : {
       $repo_base_url = 'http://dl.google.com/linux/chrome/rpm/stable/$basearch'
     }
     'Debian': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,7 @@ class google_chrome::params() {
 
   case $::osfamily {
     'RedHat' : {
-      if $::os[release][major] == '6' {
+      if $::os['release']['major'] == '6' {
 	fail("Operating system not supported by Google Chrome")
       }
       $repo_base_url = 'http://dl.google.com/linux/chrome/rpm/stable/$basearch'

--- a/spec/classes/chrome_browser_spec.rb
+++ b/spec/classes/chrome_browser_spec.rb
@@ -20,12 +20,35 @@ describe 'google_chrome' do
      end
   end
 
+  context 'does not support Enterprise Linux 6' do
+    let :facts do
+      {
+	:os => {
+	  :release  => {
+	    'major' => '6',
+	  },
+	},
+      }
+    end
+
+    it do
+      expect {
+        is_expected.to fail(/not supported/)
+      }
+    end
+  end
+
   context 'with Fedora operatingsystem' do
     let :facts do
       {
           :osfamily        => 'RedHat',
           :operatingsystem => 'Fedora',
           :lsbdistid       => 'Fedora',
+	  :os		   => {
+	    :release  => {
+	      'major' => '7',
+	    },
+	  }
       }
     end
 


### PR DESCRIPTION
Current Google Chrome stable does not support Enterprise Linux 6.  If the os major version on RedHat is 6 then fail with the message "not supported".