### PR TITLE
subtle whitespace typo in init.pp non-idempotent

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,5 +30,5 @@ class google_chrome(
   validate_re($version, ['^stable','^unstable','^beta'])
 
   class { 'google_chrome::config': } ->
-  class { 'google_chrome::install' : }
+  class { 'google_chrome::install': }
 }


### PR DESCRIPTION
(causes a second `puppet agent` or `puppet apply` run to succeed with subtle changes to the Yumrepo class parameters like baseurl and gpgkey: non-zero exit code, not fully idempotent)