### PR TITLE
Adds a description to the yum repo to remove warns

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,6 +12,7 @@ class google_chrome::config() inherits google_chrome::params {
     'RedHat': {
       yumrepo { $google_chrome::params::repo_name:
         name     => $google_chrome::params::repo_name,
+        descr    => 'Google Chrome Repo',
         enabled  => 1,
         gpgcheck => 1,
         baseurl  => $google_chrome::params::repo_base_url,


### PR DESCRIPTION
 * Removes the several warnings on puppet runs `Repository 'google-chrome' is
   missing name in configuration, using id` by adding a `descr` property to the
   repo.