### PR TITLE
Updated to give the possibility to modify all the default parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,17 @@ class { 'google_chrome':
   version => 'beta',
 }
 ```
+To modify the full set of default parameters.
+
+```puppet
+class { 'google_chrome':
+  ensure           => 'installed',
+  version          => 'unstable',
+  package_name     => 'google-chrome',
+  repo_gpg_key     => 'https://dl.google.com/linux/linux_signing_key.pub',
+  repo_gpg_key_id  => '4CCA1EAF950CEE4AB83976DCA040830F7FAC5991',
+  repo_name        => 'google-chrome',
+  defaults_file    => '/etc/default/google-chrome',
+  repo_base_url    => 'http://dl.google.com/linux/chrome/rpm/stable/x86_64'
+}
+```

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,6 @@
-class google_chrome::config() inherits google_chrome::params {
+class google_chrome::config() inherits google_chrome {
 
-  file { $google_chrome::params::defaults_file:
+  file { $google_chrome::defaults_file:
     ensure  => 'present',
     owner   => 'root',
     group   => 'root',
@@ -10,24 +10,24 @@ class google_chrome::config() inherits google_chrome::params {
 
   case $::osfamily {
     'RedHat': {
-      yumrepo { $google_chrome::params::repo_name:
-        name     => $google_chrome::params::repo_name,
-        descr    => $google_chrome::params::repo_name,
+      yumrepo { $google_chrome::repo_name:
+        name     => $google_chrome::repo_name,
+        descr    => $google_chrome::repo_name,
         enabled  => 1,
         gpgcheck => 1,
-        baseurl  => $google_chrome::params::repo_base_url,
-        gpgkey   => $google_chrome::params::repo_gpg_key,
+        baseurl  => $google_chrome::repo_base_url,
+        gpgkey   => $google_chrome::repo_gpg_key,
       }
     }
     'Debian': {
-      Exec['apt_update'] -> Package["${google_chrome::params::package_name}-${google_chrome::version}"]
+      Exec['apt_update'] -> Package["${google_chrome::package_name}-${google_chrome::version}"]
 
-      apt::source { $google_chrome::params::repo_name:
-        location => $google_chrome::params::repo_base_url,
+      apt::source { $google_chrome::repo_name:
+        location => $google_chrome::repo_base_url,
         release  => 'stable',
         key      => {
-          id     => $google_chrome::params::repo_gpg_key_id,
-          source => $google_chrome::params::repo_gpg_key,
+          id     => $google_chrome::repo_gpg_key_id,
+          source => $google_chrome::repo_gpg_key,
         },
         repos    => 'main',
         include  => {
@@ -36,9 +36,9 @@ class google_chrome::config() inherits google_chrome::params {
       }
     }
     'Suse': {
-      zypprepo { $google_chrome::params::repo_name:
-        name     => $google_chrome::params::repo_name,
-        baseurl  => $google_chrome::params::repo_base_url,
+      zypprepo { $google_chrome::repo_name:
+        name     => $google_chrome::repo_name,
+        baseurl  => $google_chrome::repo_base_url,
         enabled  => 1,
         gpgcheck => 0,
         type     => 'rpm-md',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,15 +38,17 @@
 # Copyright 2014 James Netherton
 #
 class google_chrome(
-  String $ensure                                    = $google_chrome::params::ensure,
-  Pattern[/^stable/, /^unstable/, /^beta/] $version = $google_chrome::params::version,
-  String $package_name                              = $google_chrome::params::package_name,
-  String $repo_gpg_key                              = $google_chrome::params::repo_gpg_key,
-  String $repo_gpg_key_id                           = $google_chrome::params::repo_gpg_key_id,
-  String $repo_name                                 = $google_chrome::params::repo_name,
-  String $defaults_file                             = $google_chrome::params::defaults_file,
-  String $repo_base_url                             = $google_chrome::params::repo_base_url
+  $ensure           = $google_chrome::params::ensure,
+  $version          = $google_chrome::params::version,
+  $package_name     = $google_chrome::params::package_name,
+  $repo_gpg_key     = $google_chrome::params::repo_gpg_key,
+  $repo_gpg_key_id  = $google_chrome::params::repo_gpg_key_id,
+  $repo_name        = $google_chrome::params::repo_name,
+  $defaults_file    = $google_chrome::params::defaults_file,
+  $repo_base_url    = $google_chrome::params::repo_base_url
 ) inherits google_chrome::params {
+
+  validate_re($version, ['^stable','^unstable','^beta'])
 
   class { 'google_chrome::config': }
   -> class { 'google_chrome::install': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,11 +12,25 @@
 #  include 'google_chrome'
 #
 #  class { google_chrome:
-#    version => 'unstable',
+#    ensure           => 'installed',
+#    version          => 'unstable',
+#    package_name     => 'google-chrome',
+#    repo_gpg_key     => 'https://dl.google.com/linux/linux_signing_key.pub',
+#    repo_gpg_key_id  => '4CCA1EAF950CEE4AB83976DCA040830F7FAC5991',
+#    repo_name        => 'google-chrome',
+#    defaults_file    => '/etc/default/google-chrome',
+#    repo_base_url    => 'http://dl.google.com/linux/chrome/rpm/stable/x86_64'
 #  }
 #
 #  class { google_chrome:
-#    version => 'beta',
+#    ensure           => 'installed',
+#    version          => 'beta',
+#    package_name     => 'google-chrome',
+#    repo_gpg_key     => 'https://dl.google.com/linux/linux_signing_key.pub',
+#    repo_gpg_key_id  => '4CCA1EAF950CEE4AB83976DCA040830F7FAC5991',
+#    repo_name        => 'google-chrome',
+#    defaults_file    => '/etc/default/google-chrome',
+#    repo_base_url    => 'http://dl.google.com/linux/chrome/rpm/stable/x86_64'
 #  }
 #
 # === Copyright
@@ -24,17 +38,15 @@
 # Copyright 2014 James Netherton
 #
 class google_chrome(
-  $ensure           = $google_chrome::params::ensure,
-  $version          = $google_chrome::params::version,
-  $package_name     = $google_chrome::params::package_name,
-  $repo_gpg_key     = $google_chrome::params::repo_gpg_key,
-  $repo_gpg_key_id  = $google_chrome::params::repo_gpg_key_id,
-  $repo_name        = $google_chrome::params::repo_name,
-  $defaults_file    = $google_chrome::params::defaults_file,
-  $repo_base_url    = $google_chrome::params::repo_base_url
+  String $ensure                                    = $google_chrome::params::ensure,
+  Pattern[/^stable/, /^unstable/, /^beta/] $version = $google_chrome::params::version,
+  String $package_name                              = $google_chrome::params::package_name,
+  String $repo_gpg_key                              = $google_chrome::params::repo_gpg_key,
+  String $repo_gpg_key_id                           = $google_chrome::params::repo_gpg_key_id,
+  String $repo_name                                 = $google_chrome::params::repo_name,
+  String $defaults_file                             = $google_chrome::params::defaults_file,
+  String $repo_base_url                             = $google_chrome::params::repo_base_url
 ) inherits google_chrome::params {
-
-  validate_re($version, ['^stable','^unstable','^beta'])
 
   class { 'google_chrome::config': }
   -> class { 'google_chrome::install': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,14 @@
 # Copyright 2014 James Netherton
 #
 class google_chrome(
-  $version  = $google_chrome::params::version
+  $ensure           = $google_chrome::params::ensure,
+  $version          = $google_chrome::params::version,
+  $package_name     = $google_chrome::params::package_name,
+  $repo_gpg_key     = $google_chrome::params::repo_gpg_key,
+  $repo_gpg_key_id  = $google_chrome::params::repo_gpg_key_id,
+  $repo_name        = $google_chrome::params::repo_name,
+  $defaults_file    = $google_chrome::params::defaults_file,
+  $repo_base_url    = $google_chrome::params::repo_base_url
 ) inherits google_chrome::params {
 
   validate_re($version, ['^stable','^unstable','^beta'])

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,5 @@
-class google_chrome::install() inherits google_chrome::params {
-  package { "${google_chrome::params::package_name}-${google_chrome::version}":,
-    ensure => $google_chrome::params::ensure,
+class google_chrome::install() inherits google_chrome {
+  package { "${google_chrome::package_name}-${google_chrome::version}":,
+    ensure => $google_chrome::ensure,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,5 @@
 class google_chrome::params() {
-  $ensure           = installed
+  $ensure           = 'installed'
   $version          = 'stable'
   $package_name     = 'google-chrome'
   $repo_gpg_key     = 'https://dl.google.com/linux/linux_signing_key.pub'


### PR DESCRIPTION
The module was updated mainly to give the possibility to modify all the default parameters (following this question on ask.puppet.com : https://ask.puppet.com/question/32773/keeping-the-latest-stable-chrome-installed-ubuntu/).

The following parameters are the ones that can be modified now (all defaulted to what is set in params.pp):
```
  $ensure           = $google_chrome::params::ensure,
  $version          = $google_chrome::params::version,
  $package_name     = $google_chrome::params::package_name,
  $repo_gpg_key     = $google_chrome::params::repo_gpg_key,
  $repo_gpg_key_id  = $google_chrome::params::repo_gpg_key_id,
  $repo_name        = $google_chrome::params::repo_name,
  $defaults_file    = $google_chrome::params::defaults_file,
  $repo_base_url    = $google_chrome::params::repo_base_url
```