### PR TITLE
Added a parameter for defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,25 @@ Puppet module to install the Google Chrome web browser module. Currently support
 
 ## Usage
 
+### Class: `google_chrome`
+
+Installs Google Chrome
+
+**Parameters within `google_chrome`**
+
+####`version`
+Chrome version to install. Can be one of 'stable' (the default), 'unstable' or 'beta'.
+Default: 'stable'
+
+####`defaults_proxy_pac_url`
+
+Data type: *Optional[String]*
+
+Specify proxy autoconfiguration URL.  Overrides any environment variables or settings picked via the options dialog.  
+Default: undef
+
+### Examples
+
 To install the stable version of Google Chrome, include or declare the google_chrome class.
 
 ```puppet

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,7 +5,9 @@ class google_chrome::config() inherits google_chrome {
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => "repo_add_once=\"false\"\nrepo_reenable_on_distupgrade=\"true\"\n",
+    content => epp('google_chrome/defaults-google-chrome.epp',{
+      proxy_pac_url => $google_chrome::defaults_proxy_pac_url,
+    }),
   }
 
   case $::osfamily {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,14 @@
 #
 # [*version*]
 #   Chrome version to install. Can be one of 'stable' (the default), 'unstable' or 'beta'.
+#   Default: 'stable'
+#
+# @param [Optional[String]] defaults_proxy_pac_url
+#   Specify proxy autoconfiguration URL.
+#   Overrides any environment variables or settings picked via
+#   the options dialog.
+#   Default: undef
+#
 #
 # === Examples
 #
@@ -45,6 +53,7 @@ class google_chrome(
   $repo_gpg_key_id  = $google_chrome::params::repo_gpg_key_id,
   $repo_name        = $google_chrome::params::repo_name,
   $defaults_file    = $google_chrome::params::defaults_file,
+  Optional[String] $defaults_proxy_pac_url = undef,
   $repo_base_url    = $google_chrome::params::repo_base_url
 ) inherits google_chrome::params {
 

--- a/templates/defaults-google-chrome.epp
+++ b/templates/defaults-google-chrome.epp
@@ -1,0 +1,9 @@
+<%-|
+  Optional[String] $proxy_pac_url = undef,
+|-%>
+repo_add_once="false"
+repo_reenable_on_distupgrade="true"
+<%- if $proxy_pac_url { -%>
+proxy-pac-url="<%= $proxy_pac_url %>"
+<%- } -%>
+


### PR DESCRIPTION
The defaults configuration file has several parameters that can be set.
This commit utilizes a template that sets up the framework to allow
additional default parameters to be managed.

This commit includes the new proxy-pac-url parameter.

The readme document has also been updated to include the class and
parameters.