### PR TITLE
Replace apt-key with file based key.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,10 +24,15 @@ class google_chrome::config() inherits google_chrome {
     'Debian': {
       Exec['apt_update'] -> Package["${google_chrome::package_name}-${google_chrome::version}"]
 
+      archive{"/etc/apt/trusted.gpg.d/${google_chrome::repo_name}.asc":
+        source => $google_chrome::repo_gpg_key,
+      }
+
       apt::source { $google_chrome::repo_name:
         location => $google_chrome::repo_base_url,
         release  => 'stable',
         key      => {
+          ensure => absent,
           id     => $google_chrome::repo_gpg_key_id,
           source => $google_chrome::repo_gpg_key,
         },

--- a/metadata.json
+++ b/metadata.json
@@ -37,7 +37,8 @@
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=4.0.0 <6.0.0" },
     { "name": "puppetlabs/apt", "version_requirement": ">=2.0.0 <7.0.0" },
-    { "name": "puppet/zypprepo", "version_requirement": ">=2.0.0 <3.0.0" }
+    { "name": "puppet/zypprepo", "version_requirement": ">=2.0.0 <3.0.0" },
+    { "name": "puppet/archive", "version_requirement": ">=4.0.0 <5.0.0" }
   ],
   "requirements": [
     {


### PR DESCRIPTION
apt-key does not respect the system proxy settings and is also a depricated command.
The recommendation is to load keys into the /etc/apt/trusted.gpg.d directory instead
of using apt-key.  This patch implements this functionality for debian based
OS's.

Using Archive Puppet Module for downloading gpg key as this works with https sources.

See: https://bugs.launchpad.net/ubuntu/+source/software-properties/+bug/1433761