### PR TITLE
Remove validate_ deprecation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,19 +32,17 @@
 # Copyright 2014 James Netherton
 #
 class google_chrome(
-  $ensure                 = $google_chrome::params::ensure,
-  $version                = $google_chrome::params::version,
-  $package_name           = $google_chrome::params::package_name,
-  $repo_gpg_key           = $google_chrome::params::repo_gpg_key,
-  $repo_gpg_key_id        = $google_chrome::params::repo_gpg_key_id,
-  $repo_gpg_key_options   = $google_chrome::params::repo_gpg_key_options,
-  $repo_name              = $google_chrome::params::repo_name,
-  $defaults_file          = $google_chrome::params::defaults_file,
-  $defaults_proxy_pac_url = $google_chrome::params::defaults_proxy_pac_url,
-  $repo_base_url          = $google_chrome::params::repo_base_url
+  $ensure                                   = $google_chrome::params::ensure,
+  Enum['stable','unstable','beta'] $version = $google_chrome::params::version,
+  $package_name                             = $google_chrome::params::package_name,
+  $repo_gpg_key                             = $google_chrome::params::repo_gpg_key,
+  $repo_gpg_key_id                          = $google_chrome::params::repo_gpg_key_id,
+  $repo_gpg_key_options                     = $google_chrome::params::repo_gpg_key_options,
+  $repo_name                                = $google_chrome::params::repo_name,
+  $defaults_file                            = $google_chrome::params::defaults_file,
+  $defaults_proxy_pac_url                   = $google_chrome::params::defaults_proxy_pac_url,
+  $repo_base_url                            = $google_chrome::params::repo_base_url
 ) inherits google_chrome::params {
-
-  validate_re($version, ['^stable','^unstable','^beta'])
 
   class { 'google_chrome::config': }
   -> class { 'google_chrome::install': }

--- a/metadata.json
+++ b/metadata.json
@@ -42,7 +42,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.0.0 <7.0.0"
+      "version_requirement": ">=5.0.0 <7.0.0"
     }
   ]
 }

--- a/spec/classes/chrome_browser_spec.rb
+++ b/spec/classes/chrome_browser_spec.rb
@@ -286,7 +286,7 @@ describe 'google_chrome' do
     end
 
     it 'should fail' do
-      expect { should compile }.to raise_error(/does not match/)
+      expect { should compile }.to raise_error(/Enum/)
     end
   end  
 end


### PR DESCRIPTION
With puppet 6 each compilation gives a depreation warning

```
 Puppet This method is deprecated, please use the stdlib validate_legacy function,
```

Slight change of behaviour here in that version has to be exactly
`stable`, `unstable` or `beta` whereas previously I think it only
had to be prefixed with these values. I believe this is correct however.